### PR TITLE
Angular package: fix entry point in package.json

### DIFF
--- a/packages/ds/angular/package.json
+++ b/packages/ds/angular/package.json
@@ -5,7 +5,7 @@
     "author": "IRCC-ca",
     "homepage": "https://github.com/IRCC-ca/ds-sdc#readme",
     "license": "MIT",
-    "main": "dist/angular/public-api.ts",
+    "main": "dist/public-api.d.ts",
     "directories": {
         "lib": "lib",
         "test": "__tests__"


### PR DESCRIPTION
Resolves an issue where `IRCCModule` import cannot be referenced during app build.
[Related slack conversation](https://trvjourneylab.slack.com/archives/C03QC8PFQTS/p1665593361114199)