### PR TITLE
imports fix

### DIFF
--- a/packages/ds/core/util/_theme.scss
+++ b/packages/ds/core/util/_theme.scss
@@ -5,6 +5,10 @@
 @mixin light {
     @if (color.$color-scheme == light) {
         @content;
+    } @else {
+        @media(prefers-color-scheme: light){
+            @content;
+        }
     }
 }
 
@@ -12,6 +16,10 @@
 @mixin dark {
     @if (color.$color-scheme == dark) {
         @content;
+    } @else {
+        @media(prefers-color-scheme: dark){
+            @content;
+        }
     }
 }
 

--- a/sample/src/styles.scss
+++ b/sample/src/styles.scss
@@ -4,9 +4,7 @@
 // }
 // need to update documentation for this
 
-@include ircc-ds.theme-init-required(ircc-ds.palette-journeylab(), default, large, light);
-
-
+@include ircc-ds.theme-init-required(ircc-ds.palette-journeylab(), default, large, both);
 @include ircc-ds.element-styles();
 
 


### PR DESCRIPTION
Fixing imports issue for light and dark mode.

`@include ircc-ds.theme-init-required(ircc-ds.palette-journeylab(), default, large, both);`
In the above piece of code when importing 'light' specifies light mode, 'dark' specifies dark mode and anything else will cause behaviour to be based on the user's system preference.