### PR TITLE
Removing fontawesome from project

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,8 +18,6 @@ jobs:
       run: | # Set registry and authenticate with repo token
         npm set @ircc-ca:registry=https://npm.pkg.github.com/ircc-ca
         npm set "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}"
-        npm set @fortawesome:registry=https://npm.fontawesome.com/
-        npm set "//npm.fontawesome.com/:_authToken=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}"
     - name: Install dependencies
       run: | # Install and link dependencies
         npx lerna bootstrap

--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -23,8 +23,6 @@ jobs:
       run: | # Set registry and authenticate with repo token
         npm set @ircc-ca:registry=https://npm.pkg.github.com/ircc-ca
         npm set "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}"
-        npm set @fortawesome:registry=https://npm.fontawesome.com/
-        npm set "//npm.fontawesome.com/:_authToken=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}"
     - name: "Install dependencies"
       run: | # Install and link dependencies
         npx lerna bootstrap

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,6 @@ jobs:
       run: | # Set registry and authenticate with repo token
         npm set @ircc-ca:registry=https://npm.pkg.github.com/ircc-ca
         npm set "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}"
-        npm set @fortawesome:registry=https://npm.fontawesome.com/
-        npm set "//npm.fontawesome.com/:_authToken=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}"
     - name: "Version and publish"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
     "cSpell.words": [
         "behaviour",
-        "Fontawesome",
         "ircc",
         "npmrc",
         "pseudoclass",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3869,14 +3869,6 @@
       "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-4.5.10.tgz",
       "integrity": "sha512-2hYR6r661Cq9B8zugtu6yxuOKqrVhAgfOSaPSq8XoxbC4ebsl0KOTy/vPoP+9U7JuQVLfrmikirW4a9Z0nDUug=="
     },
-    "node_modules/@fortawesome/fontawesome-pro": {
-      "version": "6.2.0",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/6.2.0/fontawesome-pro-6.2.0.tgz",
-      "integrity": "sha512-T1JhszQ75ofAaa42XWBte5KsiBb7YM6CKMZTiR3zL0CHZGBabPg8J5FgMoJYlaxgrfLf+jOebDnoB0h43ljAsA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -54459,8 +54451,7 @@
       "license": "MIT",
       "dependencies": {
         "@fontsource/inter": "^4.5.13",
-        "@fontsource/lato": "^4.5.10",
-        "@fortawesome/fontawesome-pro": "^6.2.0"
+        "@fontsource/lato": "^4.5.10"
       },
       "devDependencies": {
         "eslint-config-prettier": "^8.5.0",
@@ -58864,11 +58855,6 @@
       "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-4.5.10.tgz",
       "integrity": "sha512-2hYR6r661Cq9B8zugtu6yxuOKqrVhAgfOSaPSq8XoxbC4ebsl0KOTy/vPoP+9U7JuQVLfrmikirW4a9Z0nDUug=="
     },
-    "@fortawesome/fontawesome-pro": {
-      "version": "6.2.0",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/6.2.0/fontawesome-pro-6.2.0.tgz",
-      "integrity": "sha512-T1JhszQ75ofAaa42XWBte5KsiBb7YM6CKMZTiR3zL0CHZGBabPg8J5FgMoJYlaxgrfLf+jOebDnoB0h43ljAsA=="
-    },
     "@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -58946,7 +58932,6 @@
       "requires": {
         "@fontsource/inter": "^4.5.13",
         "@fontsource/lato": "^4.5.10",
-        "@fortawesome/fontawesome-pro": "^6.2.0",
         "eslint-config-prettier": "^8.5.0",
         "prettier": "^2.6.2"
       }

--- a/packages/ds/angular/package-lock.json
+++ b/packages/ds/angular/package-lock.json
@@ -28,8 +28,7 @@
             "license": "MIT",
             "dependencies": {
                 "@fontsource/inter": "^4.5.12",
-                "@fontsource/lato": "^4.5.9",
-                "@fortawesome/fontawesome-pro": "^6.0.0"
+                "@fontsource/lato": "^4.5.9"
             },
             "devDependencies": {
                 "eslint-config-prettier": "^8.5.0",
@@ -1602,7 +1601,6 @@
             "requires": {
                 "@fontsource/inter": "^4.5.12",
                 "@fontsource/lato": "^4.5.9",
-                "@fortawesome/fontawesome-pro": "^6.0.0",
                 "eslint-config-prettier": "^8.5.0",
                 "prettier": "^2.6.2"
             }

--- a/packages/ds/core/.npmrc
+++ b/packages/ds/core/.npmrc
@@ -1,2 +1,0 @@
-@fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken=${FONTAWESOME_NPM_AUTH_TOKEN}

--- a/packages/ds/core/package-lock.json
+++ b/packages/ds/core/package-lock.json
@@ -10,8 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@fontsource/inter": "^4.5.13",
-                "@fontsource/lato": "^4.5.10",
-                "@fortawesome/fontawesome-pro": "^6.2.0"
+                "@fontsource/lato": "^4.5.10"
             },
             "devDependencies": {
                 "eslint-config-prettier": "^8.5.0",
@@ -51,14 +50,6 @@
             "version": "4.5.10",
             "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-4.5.10.tgz",
             "integrity": "sha512-2hYR6r661Cq9B8zugtu6yxuOKqrVhAgfOSaPSq8XoxbC4ebsl0KOTy/vPoP+9U7JuQVLfrmikirW4a9Z0nDUug=="
-        },
-        "node_modules/@fortawesome/fontawesome-pro": {
-            "version": "6.2.0",
-            "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/6.2.0/fontawesome-pro-6.2.0.tgz",
-            "integrity": "sha512-T1JhszQ75ofAaa42XWBte5KsiBb7YM6CKMZTiR3zL0CHZGBabPg8J5FgMoJYlaxgrfLf+jOebDnoB0h43ljAsA==",
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.10.7",
@@ -1474,11 +1465,6 @@
             "version": "4.5.10",
             "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-4.5.10.tgz",
             "integrity": "sha512-2hYR6r661Cq9B8zugtu6yxuOKqrVhAgfOSaPSq8XoxbC4ebsl0KOTy/vPoP+9U7JuQVLfrmikirW4a9Z0nDUug=="
-        },
-        "@fortawesome/fontawesome-pro": {
-            "version": "6.2.0",
-            "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/6.2.0/fontawesome-pro-6.2.0.tgz",
-            "integrity": "sha512-T1JhszQ75ofAaa42XWBte5KsiBb7YM6CKMZTiR3zL0CHZGBabPg8J5FgMoJYlaxgrfLf+jOebDnoB0h43ljAsA=="
         },
         "@humanwhocodes/config-array": {
             "version": "0.10.7",

--- a/packages/ds/core/package.json
+++ b/packages/ds/core/package.json
@@ -38,8 +38,7 @@
     },
     "dependencies": {
         "@fontsource/inter": "^4.5.13",
-        "@fontsource/lato": "^4.5.10",
-        "@fortawesome/fontawesome-pro": "^6.2.0"
+        "@fontsource/lato": "^4.5.10"
     },
     "devDependencies": {
         "eslint-config-prettier": "^8.5.0",

--- a/packages/ds/core/tokens/checkbox/_checkbox.scss
+++ b/packages/ds/core/tokens/checkbox/_checkbox.scss
@@ -40,9 +40,15 @@
 
     &:disabled {
         --border: var(--border-disabled);
+        cursor: not-allowed;
 
         & + label {
             color: var(--text-disabled);
+        }
+
+        &:active {
+            --border: var(--border-disabled);
+            background-color: var(--surface1);
         }
     }
 

--- a/packages/ds/core/tokens/radio/_radio.scss
+++ b/packages/ds/core/tokens/radio/_radio.scss
@@ -35,7 +35,7 @@
 
     &:disabled {
         --border: var(--border-disabled);
-
+        cursor: not-allowed;
         & + label {
             color: var(--text-disabled);
         }

--- a/packages/ds/react/package-lock.json
+++ b/packages/ds/react/package-lock.json
@@ -30,8 +30,7 @@
             "license": "MIT",
             "dependencies": {
                 "@fontsource/inter": "^4.5.13",
-                "@fontsource/lato": "^4.5.10",
-                "@fortawesome/fontawesome-pro": "^6.2.0"
+                "@fontsource/lato": "^4.5.10"
             },
             "devDependencies": {
                 "eslint-config-prettier": "^8.5.0",
@@ -180,7 +179,6 @@
             "requires": {
                 "@fontsource/inter": "^4.5.13",
                 "@fontsource/lato": "^4.5.10",
-                "@fortawesome/fontawesome-pro": "^6.2.0",
                 "eslint-config-prettier": "^8.5.0",
                 "prettier": "^2.6.2"
             }

--- a/packages/ds/web/package-lock.json
+++ b/packages/ds/web/package-lock.json
@@ -31,8 +31,7 @@
       "license": "MIT",
       "dependencies": {
         "@fontsource/inter": "^4.5.13",
-        "@fontsource/lato": "^4.5.10",
-        "@fortawesome/fontawesome-pro": "^6.2.0"
+        "@fontsource/lato": "^4.5.10"
       },
       "devDependencies": {
         "eslint-config-prettier": "^8.5.0",
@@ -6976,7 +6975,6 @@
       "requires": {
         "@fontsource/inter": "^4.5.13",
         "@fontsource/lato": "^4.5.10",
-        "@fortawesome/fontawesome-pro": "^6.2.0",
         "eslint-config-prettier": "^8.5.0",
         "prettier": "^2.6.2"
       }

--- a/sample/src/index.html
+++ b/sample/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <script src="https://kit.fontawesome.com/8e16e0c619.js" crossorigin="anonymous"></script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
Replacing fontawesome package manager setup with kits setup.

-project will no longer send any icons with it - if icons are desired kits url will need to be added at project level